### PR TITLE
Use https: instead of git:

### DIFF
--- a/README.mkdn
+++ b/README.mkdn
@@ -36,7 +36,7 @@ $ mkdir crDroid
 $ cd crDroid
 
 # Install Repo in the created directory
-$ repo init -u git://github.com/crdroidandroid/android.git -b 11.0
+$ repo init -u https://github.com/crdroidandroid/android.git -b 11.0
 ```
 
 This is what you will run each time you want to pull in upstream changes. Keep in mind that on your


### PR DESCRIPTION
Fixes the following git:// protocol brownout:

fatal: remote error: 
  The unauthenticated git protocol on port 9418 is no longer supported.
Please see https://github.blog/2021-09-01-improving-git-protocol-security-github/ for more information.