### PR TITLE
manifest: lineage: android_external_ant-wireless_antradio-library from LineageOS

### DIFF
--- a/snippets/lineage.xml
+++ b/snippets/lineage.xml
@@ -11,6 +11,7 @@
   <project path="external/exfatprogs" name="LineageOS/android_external_exfatprogs" />
   <project path="external/htop" name="LineageOS/android_external_htop" />
   <project path="external/libncurses" name="LineageOS/android_external_libncurses" />
+  <project path="external/ant-wireless/antradio-library" name="LineageOS/android_external_ant-wireless_antradio-library" />
   <!--<project path="external/libnfc-nxp" name="LineageOS/android_external_libnfc-nxp" />-->
   <project path="external/nano" name="LineageOS/android_external_nano" />
   <!--<project path="external/ntfs-3g" name="LineageOS/android_external_ntfs-3g" />-->


### PR DESCRIPTION
Yeah, so for some devices when building spit out an error due to an missing library which can be resolved by cloning this into external/ant-wireless/antradio-library.