### PR TITLE
manifest: Add additional instructions for building on newer systems

### DIFF
--- a/README.mkdn
+++ b/README.mkdn
@@ -13,6 +13,12 @@ Several packages are needed in order to build crDroid
 ```
 sudo apt install bc bison build-essential ccache curl flex g++-multilib gcc-multilib git git-lfs gnupg gperf imagemagick lib32ncurses5-dev lib32readline-dev lib32z1-dev liblz4-tool libncurses5 libncurses5-dev libsdl1.2-dev libssl-dev libwxgtk3.0-gtk3-dev libxml2 libxml2-utils lzop pngcrush rsync schedtool squashfs-tools xsltproc zip zlib1g-dev
 ```
+If you're on Debian 12+ or Ubuntu 23.10+ you won't be finding `libncurses5` in the repositories anymore, you'll need to manually install them through `dpkg`
+```
+wget http://archive.ubuntu.com/ubuntu/pool/universe/n/ncurses/libtinfo5_6.4-2_amd64.deb && sudo dpkg -i libtinfo5_6.4-2_amd64.deb && rm -f libtinfo5_6.4-2_amd64.deb
+
+wget http://archive.ubuntu.com/ubuntu/pool/universe/n/ncurses/libncurses5_6.4-2_amd64.deb && sudo dpkg -i libncurses5_6.4-2_amd64.deb && rm -f libncurses5_6.4-2_amd64.deb
+```
 
 Install Repo tool
 ```bash


### PR DESCRIPTION
Debian has decided not to package libncurses5 for the new release and the amount of work that needs to be done to migrate Renderscript from Clang 3 (what uses libncurses5) to Clang 14 is not insignificant.

A possible workaround was discussed here [1]

[1] https://groups.google.com/g/android-building/c/Sv_v2ApJZug